### PR TITLE
使用 net.Buffers 避免拷贝消息体

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.7
+  - 1.8
 
 install:
     - go get -t -v ./...

--- a/go/codec.go
+++ b/go/codec.go
@@ -16,8 +16,6 @@ import (
 var _ = (link.Codec)((*codec)(nil))
 var _ = (link.Codec)((*virtualCodec)(nil))
 
-//var _ = (link.ClearSendChan)((*codec)(nil))
-
 // SizeofLen is the size of `Length` field.
 const SizeofLen = 4
 
@@ -78,13 +76,6 @@ func (c *codec) Close() error {
 	return c.conn.Close()
 }
 
-// ClearSendChan implements link/ClearSendChan interface.
-//func (c *codec) ClearSendChan(sendChan <-chan interface{}) {
-//	for msg := range sendChan {
-//		c.free(*(msg.(*[]byte)))
-//	}
-//}
-
 // ===========================================================================
 
 type MsgFormat interface {
@@ -133,7 +124,7 @@ func (c *virtualCodec) Send(msg interface{}) error {
 	}
 
 	buffers := make([][]byte, 2)
-	headBuf := c.alloc(SizeofLen + cmdIDSize)
+	headBuf := make(byte[], SizeofLen + cmdIDSize)
 	binary.LittleEndian.PutUint32(headBuf, uint32(cmdIDSize+len(msg2)))
 	binary.LittleEndian.PutUint32(headBuf[cmdConnID:], c.connID)
 	buffers[0] = headBuf

--- a/go/codec.go
+++ b/go/codec.go
@@ -124,7 +124,7 @@ func (c *virtualCodec) Send(msg interface{}) error {
 	}
 
 	buffers := make([][]byte, 2)
-	headBuf := make(byte[], SizeofLen + cmdIDSize)
+	headBuf := make([]byte, SizeofLen+cmdIDSize)
 	binary.LittleEndian.PutUint32(headBuf, uint32(cmdIDSize+len(msg2)))
 	binary.LittleEndian.PutUint32(headBuf[cmdConnID:], c.connID)
 	buffers[0] = headBuf

--- a/go/codec.go
+++ b/go/codec.go
@@ -15,7 +15,8 @@ import (
 
 var _ = (link.Codec)((*codec)(nil))
 var _ = (link.Codec)((*virtualCodec)(nil))
-var _ = (link.ClearSendChan)((*codec)(nil))
+
+//var _ = (link.ClearSendChan)((*codec)(nil))
 
 // SizeofLen is the size of `Length` field.
 const SizeofLen = 4
@@ -63,9 +64,12 @@ func (c *codec) Receive() (interface{}, error) {
 
 // Send implements link/Codec.Send() method.
 func (c *codec) Send(msg interface{}) error {
-	buffer := *(msg.(*[]byte))
-	_, err := c.conn.Write(buffer)
-	c.free(buffer)
+	if buffers, ok := (msg.([][]byte)); ok {
+		netBuf := net.Buffers(buffers)
+		_, err := netBuf.WriteTo(c.conn)
+		return err
+	}
+	_, err := c.conn.Write(msg.([]byte))
 	return err
 }
 
@@ -75,11 +79,11 @@ func (c *codec) Close() error {
 }
 
 // ClearSendChan implements link/ClearSendChan interface.
-func (c *codec) ClearSendChan(sendChan <-chan interface{}) {
-	for msg := range sendChan {
-		c.free(*(msg.(*[]byte)))
-	}
-}
+//func (c *codec) ClearSendChan(sendChan <-chan interface{}) {
+//	for msg := range sendChan {
+//		c.free(*(msg.(*[]byte)))
+//	}
+//}
 
 // ===========================================================================
 
@@ -128,11 +132,13 @@ func (c *virtualCodec) Send(msg interface{}) error {
 		return ErrTooLargePacket
 	}
 
-	buf := c.alloc(SizeofLen + cmdIDSize + len(msg2))
-	copy(buf[cmdConnID+cmdIDSize:], msg2)
-	binary.LittleEndian.PutUint32(buf, uint32(cmdIDSize+len(msg2)))
-	binary.LittleEndian.PutUint32(buf[cmdConnID:], c.connID)
-	err = c.send(c.physicalConn, buf)
+	buffers := make([][]byte, 2)
+	headBuf := c.alloc(SizeofLen + cmdIDSize)
+	binary.LittleEndian.PutUint32(headBuf, uint32(cmdIDSize+len(msg2)))
+	binary.LittleEndian.PutUint32(headBuf[cmdConnID:], c.connID)
+	buffers[0] = headBuf
+	buffers[1] = msg2
+	err = c.sendv(c.physicalConn, buffers)
 	if err != nil {
 		atomic.StoreInt64(c.lastActive, time.Now().Unix())
 	}

--- a/go/codec_test.go
+++ b/go/codec_test.go
@@ -84,7 +84,7 @@ func Test_Codec(t *testing.T) {
 		buffer2 := make([]byte, len(buffer1))
 		copy(buffer2, buffer1)
 
-		codec.Send(&buffer1)
+		codec.Send(buffer1)
 
 		buffer3, err := codec.Receive()
 		utest.IsNilNow(t, err)

--- a/go/protocol.go
+++ b/go/protocol.go
@@ -27,10 +27,17 @@ func (p *protocol) free(msg []byte) {
 	p.pool.Free(msg)
 }
 
-func (p *protocol) send(session *link.Session, msg []byte) error {
-	err := session.Send(&msg)
+func (p *protocol) sendv(session *link.Session, buffers [][]byte) error {
+	err := session.Send(buffers)
 	if err != nil {
-		p.free(msg)
+		session.Close()
+	}
+	return err
+}
+
+func (p *protocol) send(session *link.Session, msg []byte) error {
+	err := session.Send(msg)
+	if err != nil {
 		session.Close()
 	}
 	return err

--- a/go/protocol_test.go
+++ b/go/protocol_test.go
@@ -20,7 +20,7 @@ func Test_DialCmd(t *testing.T) {
 		remoteID1 := rand.Uint32()
 		msg1 := TestProto.encodeDialCmd(remoteID1)
 
-		err := codec.Send(&msg1)
+		err := codec.Send(msg1)
 		utest.IsNilNow(t, err)
 
 		msg2, err := codec.Receive()
@@ -47,7 +47,7 @@ func Test_AcceptCmd(t *testing.T) {
 		remoteID1 := rand.Uint32()
 		msg1 := TestProto.encodeAcceptCmd(connID1, remoteID1)
 
-		err := codec.Send(&msg1)
+		err := codec.Send(msg1)
 		utest.IsNilNow(t, err)
 
 		msg2, err := codec.Receive()
@@ -74,7 +74,7 @@ func Test_RefuseCmd(t *testing.T) {
 		remoteID1 := rand.Uint32()
 		msg1 := TestProto.encodeRefuseCmd(remoteID1)
 
-		err := codec.Send(&msg1)
+		err := codec.Send(msg1)
 		utest.IsNilNow(t, err)
 
 		msg2, err := codec.Receive()
@@ -101,7 +101,7 @@ func Test_ConnectCmd(t *testing.T) {
 		remoteID1 := rand.Uint32()
 		msg1 := TestProto.encodeConnectCmd(connID1, remoteID1)
 
-		err := codec.Send(&msg1)
+		err := codec.Send(msg1)
 		utest.IsNilNow(t, err)
 
 		msg2, err := codec.Receive()
@@ -128,7 +128,7 @@ func Test_CloseCmd(t *testing.T) {
 		conndID1 := rand.Uint32()
 		msg1 := TestProto.encodeCloseCmd(conndID1)
 
-		err := codec.Send(&msg1)
+		err := codec.Send(msg1)
 		utest.IsNilNow(t, err)
 
 		msg2, err := codec.Receive()
@@ -153,7 +153,7 @@ func Test_PingCmd(t *testing.T) {
 	for i := 0; i < 10000; i++ {
 		msg1 := TestProto.encodePingCmd()
 
-		err := codec.Send(&msg1)
+		err := codec.Send(msg1)
 		utest.IsNilNow(t, err)
 
 		msg2, err := codec.Receive()


### PR DESCRIPTION
Go 1.8 引入了 `net.Buffers` [1][2] ，在支持 writev 或者类似实现的系统可以一次往 `net.Conn` 写多个 `[]byte` ， 这样可以避免额外的包体内存分配和拷贝。

break change:
* 这个改变导致 `fatway` 最低支持的 Go 版本提高到 1.8 。


[1] https://golang.org/pkg/net/#Buffers
[2] https://github.com/golang/go/issues/13451